### PR TITLE
Updated dependencies and new installation instructions

### DIFF
--- a/.github/workflows/checks_tests_deploy.yml
+++ b/.github/workflows/checks_tests_deploy.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.10"]
     defaults:
       run:
         shell: bash -el {0}

--- a/conda_env.yml
+++ b/conda_env.yml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - pytorch==1.13.1
   - torchvision
-  - pandas
+  - pandas[version='<2']
   - scipy
   - numpy
   - matplotlib

--- a/conda_env.yml
+++ b/conda_env.yml
@@ -6,15 +6,15 @@ channels:
   - nvidia
   - defaults
 dependencies:
-  - pytorch==1.12
+  - pytorch==1.13.1
   - torchvision
   - pandas
   - scipy
   - numpy
   - matplotlib
   - pytables
-  - cuml=22.06
-  - cudatoolkit=11.6
+  - cuml=23.04
+  - cudatoolkit=11.8
   - protobuf[version='>3.20']
   - tensorboard
   - optuna

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,15 @@
 Changes
 =======
 
+Version 0.4.3
+*************
+
+* Fix numba related issue by updating various dependencies (https://github.com/MPI-Dortmund/tomotwin-cryoet/issues/20):
+    - Python 3.9 -> Python 3.10
+    - Rapids 22.04 -> 23.04
+    - CUDA 11.6 -> CUDA 11.8
+* Updating pyStarDB from 0.3.2 -> 0.4.2
+
 Version 0.4.0
 *************
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,7 +13,7 @@ There are three main steps to install TomoTwin:
 
 .. prompt:: bash $
 
-    mamba create -n tomotwin -c pytorch -c rapidsai -c nvidia -c conda-forge python=3.9 pytorch==1.12 torchvision pandas scipy numpy matplotlib pytables cuML=22.06 cudatoolkit=11.6 'protobuf>3.20' tensorboard  optuna mysql-connector-python
+    mamba create -n tomotwin -c pytorch -c rapidsai -c nvidia -c conda-forge python=3.10 pytorch==1.13.1 torchvision pandas scipy numpy matplotlib pytables cuML=23.04 cudatoolkit=11.8 'protobuf>3.20' tensorboard  optuna mysql-connector-python
     conda activate tomotwin
     pip install tomotwin-cryoet
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "numpy >= 1.20.0",
         "scikit-learn",
         "scikit-image",
-        "pystardb==0.3.1",
+        "pystardb>=0.4.2",
         "pandas >= 1.3",
         "pytorch-metric-learning==1.6.3",
         "numba",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "scikit-learn",
         "scikit-image",
         "pystardb>=0.4.2",
-        "pandas >= 1.3",
+        "pandas <= 2", # Because rapids does not support pandas > 1.5.3
         "pytorch-metric-learning==1.6.3",
         "numba",
         "tabulate",


### PR DESCRIPTION
This is related to issue #20 

With the most recent `numba` version, `tomotwin_tools umap` does not work anymore. One option would have been to downgrade numba, but I don't want to work with outdated libs that early in the process. So I took the opportunity to update several packages to the most recent versions.