### PR TITLE
Add option to specify a mask during embedding

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,16 @@
 Changes
 =======
 
+Version 0.5.0 (upcoming)
+*************
+
+.. admonition:: **CHANGES**
+
+    * The ``tomotwin_embed.py tomogram`` command has now a optional ``--mask`` option to select region of interestes for embeddings.
+    * The ``tomotwin_tools.py embedding_mask`` now estimates a ROI mask that masks out some portions of empty tomogram volume. Using the generated mask when running ``tomotwin_embed.py tomogram``, the embeddings step is 2 times faster. CAUTION: In TomoTwin 0.4 the ``embeddings_mask`` command calculated a label mask for the clustering workflow. This functionality now happens automatically during the calculation of the umap (``tomotwin_tools.py umap``).
+    * For the clustering workflow, you can calculate the medoid instead of columswise average. This should be a much better representation of the cluster center.
+
+
 Version 0.4.3
 *************
 
@@ -14,7 +24,7 @@ Version 0.4.0
 *************
 
 * Official clustering workflow release. Please checkout the updated installation instructions and in depth tutorial.
-* Added important tools like ``tomotwin_tools umap`` and ``tomotwin_tools embeddings_mask``
+* Added important tools like ``tomotwin_tools.py umap`` and ``tomotwin_tools.py embeddings_mask``
 * Added more unit tests
 
 Version 0.3.0

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -58,7 +58,7 @@ Download latest model
 
 :Number of proteins: 120
 
-:Link: `https <https://ftp.gwdg.de/pub/misc/sphire/TomoTwin/models/tomotwin_model_p120_052022_loss.pth>`_
+:Link: `Zendodo <https://doi.org/10.5281/zenodo.8137931>`_
 
 System requirements
 ^^^^^^^^^^^^^^^^^^^

--- a/docs/tutorials/text_modules/embed.rst
+++ b/docs/tutorials/text_modules/embed.rst
@@ -8,7 +8,7 @@ To embed your tomogram using two GPUs use:
 
 .. admonition:: Speed up embedding using ROI mask
 
-    With TomoTwin 0.4.4, the emedding command supports the use of masks. With masks you can define which regions of your tomogram get actually embedded and therefore speedup the embbeding.
+    With TomoTwin 0.5, the emedding command supports the use of masks. With masks you can define which regions of your tomogram get actually embedded and therefore speedup the embbeding.
     We also provide new tools that calculates mask that excludes areas that probably does not contain any protein. You can run it with:
 
     .. prompt:: bash $

--- a/docs/tutorials/text_modules/embed.rst
+++ b/docs/tutorials/text_modules/embed.rst
@@ -5,3 +5,19 @@ To embed your tomogram using two GPUs use:
 .. prompt:: bash $
 
     CUDA_VISIBLE_DEVICES=0,1 tomotwin_embed.py tomogram -m LATEST_TOMOTWIN_MODEL.pth -v your_tomo_a10.mrc -b 256 -o out/embed/tomo/ -s 2
+
+.. admonition:: Speed up embedding using ROI mask
+
+    With TomoTwin 0.4.4, the emedding command supports the use of masks. With masks you can define which regions of your tomogram get actually embedded and therefore speedup the embbeding.
+    We also provide new tools that calculates mask that excludes areas that probably does not contain any protein. You can run it with:
+
+    .. prompt:: bash $
+
+        tomotwin_tools.py embedding_mask -i your_tomo_a10.mrc -o out/mask/
+
+    The mask you find there can be used when running ``tomotwin_embed.py`` using the argument ``--mask``.
+    As this is still experimental, please check if the masks do not exclude any important areas. You can do that easiliy with napari by opening the tomogram and your mask and then change the opacity of your mask:
+
+    .. prompt:: bash $
+
+        napari your_tomo_a10.mrc out_mask/your_tomo_a10_mask.mrc

--- a/docs/tutorials/tut02_cluster.rst
+++ b/docs/tutorials/tut02_cluster.rst
@@ -16,7 +16,7 @@ Now we will approximate the tomogram embeddings to 2D to allow for efficient vis
 
 .. prompt:: bash $
 
-    tomotwin_tools.py umap -i your_tomo_a10/embed/tomo/tomo_embeddings.temb -o your_tomo_a10/clustering/
+    tomotwin_tools.py umap -i out/embed/tomo/tomo_embeddings.temb -o out/clustering/
 
 .. note::
 
@@ -27,7 +27,7 @@ Additionally, we will generate a mask of the embeddings to allow us to track whi
 
 .. prompt:: bash $
 
-    tomotwin_tools.py embedding_mask -i your_tomo_a10/embed/tomo/tomo_embeddings.temb -o your_tomo_a10/clustering/
+    tomotwin_tools.py embedding_mask -i out/embed/tomo/tomo_embeddings.temb -o out/clustering/
 
 4. Load data for clustering in Napari
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -36,7 +36,7 @@ Now that we have all the input files for the clustering workflow we can get star
 
 .. prompt:: bash $
 
-    napari your_tomo_a10.mrc your_tomo_a10/clustering/your_tomo_a10_embedding_label_mask.mrci
+    napari your_tomo_a10.mrc out/clustering/your_tomo_a10_embedding_label_mask.mrci
 
 Next open the napari-tomotwin clustering tool via :guilabel:`Plugins` -> :guilabel:`napari-tomotwin` -> :guilabel:`Cluster UMAP embeddings`. Then choose the :guilabel:`Path to UMAP` by clicking on :guilabel:`Select file` and provide the path to your :file:`your_tomo_a10_embeddings.tumap`. 
 Click :guilabel:`Load` and after a second, a 2D plot of the umap embeddings should appear in the plugin window.
@@ -101,7 +101,7 @@ The map command will calculate the pairwise distances/similarity between the tar
 
 .. prompt:: bash $
 
-    tomotwin_map.py distance -r your_tomo_a10/clustering/cluster_targets.temb -v your_tomo_a10/embed/tomo/your_tomo_a10_embeddings.temb -o your_tomo_a10/map/
+    tomotwin_map.py distance -r out/clustering/cluster_targets.temb -v out/embed/tomo/your_tomo_a10_embeddings.temb -o out/map/
 
 8. Localize potential particles
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/tutorials/tut02_cluster.rst
+++ b/docs/tutorials/tut02_cluster.rst
@@ -23,11 +23,7 @@ Now we will approximate the tomogram embeddings to 2D to allow for efficient vis
     If you encounter an out of memory error here, you may need to reduce the :guilabel:`fit_sample_size` and/or :guilabel:`chunk_size` values (default 400,000).
 
 
-Additionally, we will generate a mask of the embeddings to allow us to track which UMAP values correspond to which points in the tomogram. To generate this mask:
-
-.. prompt:: bash $
-
-    tomotwin_tools.py embedding_mask -i out/embed/tomo/tomo_embeddings.temb -o out/clustering/
+Additionally, it generated a mask (`tomo_embeddings_label_mask.mrci`) of the embeddings to allow us to track which UMAP values correspond to which points in the tomogram.
 
 4. Load data for clustering in Napari
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/test_boxer.py
+++ b/tests/test_boxer.py
@@ -40,6 +40,21 @@ class MyTestCase(unittest.TestCase):
         boxes = boxer.box(tomogram=tomo)
         self.assertEqual(len(boxes), 1)
 
+    def test_SlidingWindowBoxer_stride2_mask_wrongshape(self):
+        import numpy as np
+        tomo = np.random.randn(9, 9, 9)
+        mask = np.zeros(shape=(8, 8, 8)) # Wrong mask shape!
+        mask[3:6, 3:6, 3:6] = 1
+        mask = mask != 0
+
+        boxer = SlidingWindowBoxer(
+            stride=3,
+            box_size=3,
+            mask=mask
+        )
+        self.assertRaises(AssertionError,boxer.box,tomo)
+
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_boxer.py
+++ b/tests/test_boxer.py
@@ -40,21 +40,6 @@ class MyTestCase(unittest.TestCase):
         boxes = boxer.box(tomogram=tomo)
         self.assertEqual(len(boxes), 1)
 
-    def test_SlidingWindowBoxer_stride2_mask_wrongshape(self):
-        import numpy as np
-        tomo = np.random.randn(9, 9, 9)
-        mask = np.zeros(shape=(8, 8, 8)) # Wrong mask shape!
-        mask[3:6, 3:6, 3:6] = 1
-        mask = mask != 0
-
-        boxer = SlidingWindowBoxer(
-            stride=3,
-            box_size=3,
-            mask=mask
-        )
-        self.assertRaises(AssertionError,boxer.box,tomo)
-
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_boxer.py
+++ b/tests/test_boxer.py
@@ -11,7 +11,7 @@ class MyTestCase(unittest.TestCase):
         tomo = np.random.randn(9,9,9)
         boxes = boxer.box(tomogram=tomo)
 
-        self.assertEqual(boxes.volumes.shape[0]*boxes.volumes.shape[1]*boxes.volumes.shape[2], 7*7*7)
+        self.assertEqual(7*7*7,len(boxes))
 
     def test_SlidingWindowBoxer_stride2(self):
         boxer = SlidingWindowBoxer(
@@ -21,7 +21,24 @@ class MyTestCase(unittest.TestCase):
         import numpy as np
         tomo = np.random.randn(9,9,9)
         boxes = boxer.box(tomogram=tomo)
-        self.assertEqual(boxes.volumes.shape[0]*boxes.volumes.shape[1]*boxes.volumes.shape[2], 4*4*4)
+        self.assertEqual(len(boxes), 4*4*4)
+
+    def test_SlidingWindowBoxer_stride2_mask(self):
+
+        import numpy as np
+        tomo = np.random.randn(9, 9, 9)
+        mask = np.zeros(shape=(9,9,9))
+        mask[3:6,3:6,3:6] = 1
+        mask = mask != 0
+
+        boxer = SlidingWindowBoxer(
+            stride=3,
+            box_size=3,
+            mask=mask
+        )
+
+        boxes = boxer.box(tomogram=tomo)
+        self.assertEqual(len(boxes), 1)
 
 
 if __name__ == '__main__':

--- a/tests/test_volumedata.py
+++ b/tests/test_volumedata.py
@@ -1,5 +1,6 @@
 import unittest
-from tomotwin.modules.inference.volumedata import SlidingWindowVolumeData
+from tomotwin.modules.inference.volumedata import SimpleVolumeData
+from tomotwin.modules.inference.boxer import SlidingWindowBoxer
 import numpy as np
 import numpy.lib.stride_tricks as tricks
 
@@ -15,18 +16,18 @@ class MyTestCase(unittest.TestCase):
         box_size = 3
         stride = 2
 
-        window_shape = (box_size, box_size, box_size)
-        sliding_window_views = tricks.sliding_window_view(
-            vol, window_shape=window_shape
-        )
+        sliding_window_strides, center_coords = SlidingWindowBoxer._calc_sliding_volumes(
+            tomogram=vol,
+            stride=(stride,stride,stride),
+            box_size=box_size
 
-        sliding_window_strides = sliding_window_views[
-                                 :: stride, :: stride, :: stride
-                                 ]
-        dat = SlidingWindowVolumeData(volumes=sliding_window_strides, stride=stride, boxsize=box_size)
+
+        )
+        dat = SimpleVolumeData(volumes=sliding_window_strides)
 
         for i in range(len(dat)):
-            loc = dat.get_localization(i)
+            loc = center_coords[i]
+
             sub = dat[i]
             if loc[0] == pos0 and loc[1] == pos1 and loc[2] == pos2:
                 self.assertEqual(sub[1, 1, 1], val)

--- a/tests/test_volumedata.py
+++ b/tests/test_volumedata.py
@@ -16,17 +16,16 @@ class MyTestCase(unittest.TestCase):
         box_size = 3
         stride = 2
 
-        sliding_window_strides, center_coords = SlidingWindowBoxer._calc_sliding_volumes(
+        sliding_window_strides = SlidingWindowBoxer._calc_sliding_volumes(
             tomogram=vol,
             stride=(stride,stride,stride),
-            box_size=box_size
-
-
+            window_shape=(box_size,box_size,box_size)
         )
-        dat = SimpleVolumeData(volumes=sliding_window_strides)
+        roi = SlidingWindowBoxer._calc_volume_roi(sliding_window_strides,stride=(stride,stride,stride),box_size=box_size)
+        dat = SimpleVolumeData(volumes=sliding_window_strides, roi=roi)
 
         for i in range(len(dat)):
-            loc = center_coords[i]
+            loc = roi.center_coords[i]
 
             sub = dat[i]
             if loc[0] == pos0 and loc[1] == pos1 and loc[2] == pos2:

--- a/tomotwin/embed_main.py
+++ b/tomotwin/embed_main.py
@@ -486,6 +486,10 @@ def embed_tomogram(
     Embeds a tomogram
     :return: DataFrame of embeddings
     """
+
+    if mask is not None:
+        assert tomo.shape == mask.shape, f"Tomogram shape ({tomo.shape}) and mask shape ({mask.shape}) need to be equal."
+
     if conf.zrange:
         hb = int((window_size - 1) // 2)
         minz = max(0, conf.zrange[0] - hb)

--- a/tomotwin/embed_main.py
+++ b/tomotwin/embed_main.py
@@ -407,7 +407,7 @@ def sliding_window_embedding(
     embeddings = embedor.embed(volume_data=boxes)
     positions = []
     for i in range(embeddings.shape[0]):
-        positions.append(boxes.get_localization(i))
+        positions.append(boxer.get_localization(i))
     positions = np.array(positions)
     embeddings = np.hstack([positions, embeddings])
 

--- a/tomotwin/modules/inference/argparse_embed_ui.py
+++ b/tomotwin/modules/inference/argparse_embed_ui.py
@@ -393,6 +393,7 @@ class EmbedArgParseUI(EmbedUI):
         self.stride = None
         self.mode = None
         self.zrange = None
+        self.maskpth = None
 
     def run(self, args=None) -> None:
         parser = self.create_parser()
@@ -413,6 +414,7 @@ class EmbedArgParseUI(EmbedUI):
             self.zrange = args.zrange
             if len(self.stride) == 1:
                 self.stride = self.stride*3
+            self.maskpth = args.mask
 
     def get_embed_configuration(self) -> EmbedConfiguration:
         conf = EmbedConfiguration(
@@ -422,7 +424,8 @@ class EmbedArgParseUI(EmbedUI):
             mode=self.mode,
             batchsize=self.batchsize,
             stride=self.stride,
-            zrange=self.zrange
+            zrange=self.zrange,
+            maskpth=self.maskpth
         )
         return conf
 
@@ -465,6 +468,8 @@ class EmbedArgParseUI(EmbedUI):
             required=True,
             help="All output files are written in that path.",
         )
+
+
 
     @staticmethod
     def create_tomo_parser(parser):
@@ -521,6 +526,14 @@ class EmbedArgParseUI(EmbedUI):
             default=None,
             nargs=2,
             help="Minimum z and maximum z for to run the sliding window on. Handy to skip the void volume in order to speed up the embedding.",
+        )
+
+        parser.add_argument(
+            "--mask",
+            type=str,
+            required=False,
+            default=None,
+            help="Path to binary mask to define embedding region (mrc format). All values != 0 are interpreted as 'True'.",
         )
 
     def create_parser(self) -> argparse.ArgumentParser:

--- a/tomotwin/modules/inference/boxer.py
+++ b/tomotwin/modules/inference/boxer.py
@@ -375,18 +375,15 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
   defined by the Mozilla Public License, v. 2.0.
 """
 
+import itertools
 from abc import ABC, abstractmethod
-from typing import Union, Tuple, List
+from typing import Union, Tuple
 
-import numpy.lib.stride_tricks as tricks
 import numpy as np
+import numpy.lib.stride_tricks as tricks
 from numpy.typing import NDArray
 
-import itertools
-
 from tomotwin.modules.inference.volumedata import SimpleVolumeData, VolumeROI
-
-
 
 
 class Boxer(ABC):
@@ -516,5 +513,3 @@ class SlidingWindowBoxer(Boxer):
         )
 
         return data
-
-

--- a/tomotwin/modules/inference/boxer.py
+++ b/tomotwin/modules/inference/boxer.py
@@ -470,6 +470,8 @@ class SlidingWindowBoxer(Boxer):
                 raise InvalidZRangeConfiguration()
 
             tomogram = tomogram[self.zrange[0]:self.zrange[1]]
+        if self.mask is not None:
+            assert tomogram.shape == self.mask.shape, f"Tomogram shape ({tomogram.shape}) and mask shape ({self.mask.shape}) need to be equal."
 
         sliding_window_volumes, self.center_coords = SlidingWindowBoxer._calc_sliding_volumes(
             tomogram=tomogram,
@@ -481,7 +483,6 @@ class SlidingWindowBoxer(Boxer):
         # Mask if necessary
         if self.mask is not None:
             def _check_in_mask(row):
-                print(row)
                 c = tuple(row.astype(int).astype(int).tolist())
                 return self.mask[c]
             mask = np.apply_along_axis(_check_in_mask, axis=1, arr=self.center_coords)

--- a/tomotwin/modules/inference/boxer.py
+++ b/tomotwin/modules/inference/boxer.py
@@ -494,8 +494,6 @@ class SlidingWindowBoxer(Boxer):
 
             tomogram = tomogram[self.zrange[0]:self.zrange[1]]
 
-        if self.mask is not None:
-            assert tomogram.shape == self.mask.shape, f"Tomogram shape ({tomogram.shape}) and mask shape ({self.mask.shape}) need to be equal."
 
         sliding_window_volumes = SlidingWindowBoxer._calc_sliding_volumes(
             tomogram=tomogram,

--- a/tomotwin/modules/inference/embed_ui.py
+++ b/tomotwin/modules/inference/embed_ui.py
@@ -408,6 +408,7 @@ class EmbedConfiguration:
     batchsize: int
     stride: int = None
     zrange: Tuple[int,int] = None
+    maskpth: str = None
 
 
 class EmbedUI(ABC):

--- a/tomotwin/modules/inference/volumedata.py
+++ b/tomotwin/modules/inference/volumedata.py
@@ -401,9 +401,9 @@ class VolumeDataset(ABC):
     def __getitem__(self, itemindex) -> np.array:
         """Return the an item with a certain index"""
 
+    @abstractmethod
     def get_localization(self, itemindex) -> Tuple[int, int, int]:
         """Returns the center positions of an item"""
-        return self.center_coords[itemindex]
 
 
 class FileNameVolumeDataset(VolumeDataset):

--- a/tomotwin/modules/inference/volumedata.py
+++ b/tomotwin/modules/inference/volumedata.py
@@ -375,10 +375,10 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
   defined by the Mozilla Public License, v. 2.0.
 """
 
-import itertools
+
 from abc import ABC, abstractmethod
 from typing import Tuple, List, Callable
-
+import itertools
 import numpy as np
 
 
@@ -395,13 +395,11 @@ class VolumeDataset(ABC):
     def __getitem__(self, itemindex) -> np.array:
         """Return the an item with a certain index"""
 
-    @abstractmethod
-    def get_localization(self, itemindex) -> Tuple[int, int, int]:
-        """Returns the center positions of an item"""
+
 
 
 class FileNameVolumeDataset(VolumeDataset):
-    """Here the subvolumes are representent by individual files"""
+    """Here the subvolumes are represented by individual files"""
 
     def __init__(self, volumes: List[str], filereader: Callable[[str], np.array]):
         self.volumes = volumes
@@ -412,47 +410,25 @@ class FileNameVolumeDataset(VolumeDataset):
         volume = self.filereader(pth)
         return volume
 
-    def get_localization(self, itemindex) -> Tuple[float, float, float]:
-        return None
-
     def __len__(self) -> int:
         return len(self.volumes)
 
 
-class SlidingWindowVolumeData(VolumeDataset):
+class SimpleVolumeData(VolumeDataset):
     """
-    Represents a volume datset that came from a sliding window.
+    Represents a volume dataset that came from a sliding window.
     """
 
-    def __init__(self, volumes: np.array, stride: Tuple, boxsize: int, zrange: Tuple[int, int] = None):
+    def __init__(self, volumes: np.array):
         """
-        :param volumes: array with shape (X,Y,Z,BS,BS,BS), where was BS is the box size and X,Y,Z relate
+        :param volumes: array with shape (N,BS,BS,BS), where was BS is the box size and X,Y,Z relate
         to the position of the subvolume.
         """
         self.volumes = volumes
-        self.stride = stride
-        self.boxsize = boxsize
-        self.minz = None
-        self.maxz = None
-
-        self.center_coords = {}
-        self.indicies = {}
-
-
-        self.indicies = np.array(list(itertools.product(range(volumes.shape[0]), range(volumes.shape[1]),range(volumes.shape[2]))))
-        self.center_coords = self.indicies * self.stride + (self.boxsize-1)/2
-        if zrange:
-            self.center_coords[:,0] = zrange[0] + self.center_coords[:,0]
-
 
     def __len__(self) -> int:
-        return len(self.center_coords)
+        return self.volumes.shape[0]
 
     def __getitem__(self, itemindex) -> np.array:
-        location = self.indicies[itemindex]
-        vol = self.volumes[tuple(location)]
+        vol = self.volumes[itemindex]
         return vol
-
-    def get_localization(self, itemindex) -> Tuple[float, float, float]:
-        """Return the center position"""
-        return (self.center_coords[itemindex][0],self.center_coords[itemindex][1],self.center_coords[itemindex][2])

--- a/tomotwin/modules/inference/volumedata.py
+++ b/tomotwin/modules/inference/volumedata.py
@@ -377,10 +377,11 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 
 
 from abc import ABC, abstractmethod
-from typing import Tuple, List, Callable
-import itertools
-import numpy as np
 from dataclasses import dataclass
+from typing import Tuple, List, Callable
+
+import numpy as np
+
 
 @dataclass
 class VolumeROI:
@@ -451,5 +452,3 @@ class SimpleVolumeData(VolumeDataset):
 
     def get_localization(self, itemindex) -> Tuple[int, int, int]:
         return self.roi.center_coords[itemindex]
-
-

--- a/tomotwin/modules/inference/volumedata.py
+++ b/tomotwin/modules/inference/volumedata.py
@@ -385,6 +385,9 @@ import numpy as np
 
 @dataclass
 class VolumeROI:
+    '''
+    Represents a region of interesion within a volume
+    '''
     indicis: np.array
     center_coords: np.array
 

--- a/tomotwin/modules/tools/embedding_mask.py
+++ b/tomotwin/modules/tools/embedding_mask.py
@@ -389,7 +389,7 @@ from tomotwin.modules.tools.tomotwintool import TomoTwinTool
 
 class EmbeddingMaskTool(TomoTwinTool):
     """
-    Tools to create mask with label IDs for tomogram embeddings
+    Tools to create ROI of embedding
     """
 
     def get_command_name(self) -> str:


### PR DESCRIPTION
As requested by  @cmccaffe 

Its currently building, but should then be available as v0.4.4b0 at https://pypi.org/project/tomotwin-cryoet/#history

Once installed, you will find a `--mask` option in the embed command.

Inspired by `isonet`, I'm also playing with a method to generate meaningful masks quickly.  But thats not yet included in this PR