### PR TITLE
use napari 0.4.17 for now

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,7 +24,7 @@ Here we assume that you don't have napari installed. Please do:
 
 .. prompt:: bash $
 
-    mamba create -y -n napari-tomotwin -c conda-forge python=3.10 napari=0.4.18 pyqt pip
+    mamba create -y -n napari-tomotwin -c conda-forge python=3.10 napari=0.4.17 pyqt pip
     conda activate napari-tomotwin
 
 Install the required plugins `napari-boxmanager` and `napari-tomotwin` via pip:


### PR DESCRIPTION
Because of a bug in napari 0.4.18 the clustering does not work anymore:

https://github.com/napari/napari/issues/6077

Changed the install instructions back to 0.4.17