### PR TITLE
Use stable pytorch 2.1

### DIFF
--- a/conda_env_tomotwin.yml
+++ b/conda_env_tomotwin.yml
@@ -6,6 +6,8 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - pytorch[version='>=2.1']
+  - torchvision
   - pandas[version='<2']
   - scipy
   - numpy
@@ -19,8 +21,5 @@ dependencies:
   - mysql-connector-python
   - pip
   - pip:
-      - --extra-index-url https://download.pytorch.org/whl/nightly/cu118
-      - torch==2.1.0.dev20230822+cu118
-      - torchvision==0.16.0.dev20230822
       - tomotwin-cryoet
 

--- a/conda_env_tomotwin.yml
+++ b/conda_env_tomotwin.yml
@@ -1,7 +1,7 @@
 name: tomotwin
 channels:
   - nvidia
-  - pytorch-nightly
+  - pytorch
   - rapidsai
   - conda-forge
   - defaults


### PR DESCRIPTION
As pytorch 2.1 is released, we don't need to depend on the the nightly build anymore