### PR TITLE
increase timeout of the dataloader to 180 seconds.

### DIFF
--- a/tomotwin/modules/training/torchtrainer.py
+++ b/tomotwin/modules/training/torchtrainer.py
@@ -508,7 +508,7 @@ class TorchTrainer(Trainer):
             num_workers=self.workers,
             pin_memory=False,
             # prefetch_factor=5,
-            timeout=60,
+            timeout=180,
         )
 
         test_loader = None


### PR DESCRIPTION
 On some clusters (like ours) sometimes long timeout happen when generating batches during training.