### PR TITLE
Add new umap and filter options

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,6 +1,13 @@
 Changes
 =======
 
+Version 0.7.0
+*************
+
+* Fixes a bug in ``tomotwin_embed.py`` which leads to crashes because of duplicate embeddings
+* Adds the experimental flag `--cosine` to the command ``tomotwin_tools.py umap`` which in theory should give better umaps (but its also slower).
+* Adds the experimental floag ``--lower`` and ``--concat`` to the command ``tomotwin_tools.py filter_embedding``. With the new flags you can select embeddings which are at a certain distance to one or multiple references. This is handy if you want to fine tune your manuel selected reference targets.
+
 Version 0.6.0
 *************
 

--- a/docs/changes_.rst
+++ b/docs/changes_.rst
@@ -1,12 +1,16 @@
 Changes
 =======
 
+
 Version 0.7.0
 *************
 
 * Fixes a bug in ``tomotwin_embed.py`` which leads to crashes because of duplicate embeddings
 * Adds the experimental flag `--cosine` to the command ``tomotwin_tools.py umap`` which in theory should give better umaps (but its also slower).
 * Adds the experimental floag ``--lower`` and ``--concat`` to the command ``tomotwin_tools.py filter_embedding``. With the new flags you can select embeddings which are at a certain distance to one or multiple references. This is handy if you want to fine tune your manuel selected reference targets.
+
+Version 0.6.1
+*************
 
 Version 0.6.0
 *************

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ User Guide: full table of contents
    installation
    tutorials/tutorials_overview
    developer/devs
-   changes
+   Changes <https://github.com/MPI-Dortmund/tomotwin-cryoet/releases>
 
 Citation
 ========

--- a/tomotwin/modules/tools/filter_embedding.py
+++ b/tomotwin/modules/tools/filter_embedding.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 
+import numpy as np
 import pandas as pd
 
 from tomotwin.modules.tools.tomotwintool import TomoTwinTool
@@ -29,28 +30,57 @@ class FilterTool(TomoTwinTool):
                             help='Embeddings file')
 
         parser.add_argument('-m', '--map', type=str, required=True,
-                            help='Map file for median embedding')
+                            help='tmap file')
 
         parser.add_argument('-t', '--threshold', type=float, required=True,
-                            help='All embeddings higher than this similarty threshold are discarded')
+                            help='All embeddings higher (use --lower otherwise) than this similarty threshold are discarded')
 
         parser.add_argument('-o', '--output', type=str, required=True,
                             help='Output folder')
 
+        parser.add_argument('--lower',
+                            action='store_true',
+                            help="Discard embeddings lower than given threshold")
+
+        parser.add_argument('--concat',
+                            action='store_true',
+                            help="Concatenate all filtered embeddings into one embedding file")
+
     from typing import List
     @staticmethod
-    def filter_embeddings(embeddings: pd.DataFrame, map_results: pd.DataFrame, threshold: float) -> List[pd.DataFrame]:
+    def filter_embeddings(embeddings: pd.DataFrame, map_results: pd.DataFrame, threshold: float, discard_lower=False,
+                          concat=False) -> List[pd.DataFrame]:
         """
         Removes all embeddings with a similarity to the median embedding higher than the threshold. Runs filtering for
         each reference in map_results seperately
         """
+
+        def apply_thresh(tmap: pd.DataFrame, thresh: float, discard_lower: bool):
+            if discard_lower:
+                return tmap >= thresh
+            else:
+                return tmap < thresh
+
+
         filtered_embeddings = []
         map_results_no_coords = map_results.drop(['X', 'Y', 'Z'], axis=1)
+        masks = []
         for ref_index, reference in enumerate(map_results_no_coords):
             print(f"Filter reference {map_results_no_coords.attrs['references'][ref_index]} (Map column: {reference})")
-            mask = map_results_no_coords[reference] < threshold
+
+            mask = apply_thresh(map_results_no_coords[reference], threshold, discard_lower)
             mask = mask.to_numpy()
-            filtered_embeddings.append(embeddings.iloc[mask])
+
+            if not concat:
+                filtered_embeddings.append(embeddings.iloc[mask])
+            else:
+                masks.append(mask)
+
+        if concat:
+            m = masks[0]
+            for i in range(1, len(masks)):
+                m = np.logical_or(m, masks[i])
+            filtered_embeddings.append(embeddings.iloc[m])
 
         return filtered_embeddings
 
@@ -61,10 +91,18 @@ class FilterTool(TomoTwinTool):
 
         filtered = self.filter_embeddings(embeddings=tomo_embeddings,
                                           map_results=tomo_map,
-                                          threshold=args.threshold)
+                                          threshold=args.threshold,
+                                          discard_lower=args.lower,
+                                          concat=args.concat)
         embedding_filename = os.path.splitext(os.path.basename(args.input))[0]
-        for emb_index, emb in enumerate(filtered):
-            ref_name = os.path.splitext(os.path.basename(tomo_map.attrs['references'][emb_index]))[0]
-            out=os.path.join(args.output,f"{embedding_filename}_filtered_{ref_name}.temb")
+        if not args.concat:
+            for emb_index, emb in enumerate(filtered):
+                ref_name = os.path.splitext(os.path.basename(tomo_map.attrs['references'][emb_index]))[0]
+                out = os.path.join(args.output, f"{embedding_filename}_filtered_{ref_name}.temb")
+                emb.to_pickle(out)
+                print(f"Wrote {out} - removed {100 - len(emb) / len(tomo_embeddings) * 100:.2f}% embedding points")
+        else:
+            emb = filtered[0]
+            out = os.path.join(args.output, f"{embedding_filename}_filtered_allrefs.temb")
             emb.to_pickle(out)
-            print(f"Wrote {out} - removed {100 - len(emb)/len(tomo_embeddings)*100:.2f}% embedding points")
+            print(f"Wrote {out} - removed {100 - len(emb) / len(tomo_embeddings) * 100:.2f}% embedding points")

--- a/tomotwin/modules/tools/filter_embedding.py
+++ b/tomotwin/modules/tools/filter_embedding.py
@@ -58,8 +58,7 @@ class FilterTool(TomoTwinTool):
         def apply_thresh(tmap: pd.DataFrame, thresh: float, discard_lower: bool):
             if discard_lower:
                 return tmap >= thresh
-            else:
-                return tmap < thresh
+            return tmap < thresh
 
 
         filtered_embeddings = []

--- a/tomotwin/modules/tools/umap.py
+++ b/tomotwin/modules/tools/umap.py
@@ -48,6 +48,11 @@ class UmapTool(TomoTwinTool):
         parser.add_argument('--chunk_size', type=int, default=400000,
                             help='Chunk size for transform all data')
 
+        parser.add_argument('--cosine',
+                            action='store_true',
+                            help="Use cosine metric for estimating metric",
+                            default=False)
+
         return parser
 
     def calcuate_umap(
@@ -56,7 +61,8 @@ class UmapTool(TomoTwinTool):
             transform_chunk_size: int,
             reducer: cuml.UMAP = None,
             ncomponents=2,
-            neighbors: int = 200) -> typing.Tuple[ArrayLike, cuml.UMAP]:
+            neighbors: int = 200,
+            metric: str = "euclidean") -> typing.Tuple[ArrayLike, cuml.UMAP]:
         print("Prepare data")
 
         fit_sample = embeddings.sample(n=min(len(embeddings),fit_sample_size), random_state=17)
@@ -68,7 +74,8 @@ class UmapTool(TomoTwinTool):
                 n_components=ncomponents,
                 n_epochs=None,  # means automatic selection
                 min_dist=0.0,
-                random_state=19
+                random_state=19,
+                metric=metric
             )
             print(f"Fit umap on {len(fit_sample)} samples")
             reducer.fit(fit_sample)
@@ -117,12 +124,16 @@ class UmapTool(TomoTwinTool):
         model = None
         if args.model:
             model = pickle.load(open(args.model, "rb"))
+        metric = "euclidean"
+        if args.cosine:
+            metric = "cosine"
         umap_embeddings, fitted_umap = self.calcuate_umap(embeddings=embeddings,
                                                           fit_sample_size=args.fit_sample_size,
                                                           transform_chunk_size=args.chunk_size,
                                                           reducer=model,
                                                           neighbors=args.neighbors,
-                                                          ncomponents=args.ncomponents)
+                                                          ncomponents=args.ncomponents,
+                                                          metric=metric)
 
 
 


### PR DESCRIPTION
This pull request adds a cosine option for umap (should in theory give better results, but is slower) and extends the filter capabilities of the `filter_embedding` tool. Using the new `--concat` and `--lower` flag you can select those embeddings which are very similar to reference. This is handy if you want to fine tune your reference target.