### PR TITLE
Add fast median mask estimation

### DIFF
--- a/tomotwin/embed_main.py
+++ b/tomotwin/embed_main.py
@@ -606,6 +606,16 @@ def run_distr(config, world_size: int):
         args=([config, world_size]),
         nprocs=world_size
     )
+
+
+def start(config):
+    # suppose we have 2 gpus
+    if config.distr_mode == DistrMode.DDP:
+        world_size = torch.cuda.device_count()
+        run_distr(config, world_size)
+    else:
+        run(None, config, None)
+
 def _main_():
     ########################
     # Get configuration from user interface
@@ -614,13 +624,8 @@ def _main_():
     ui.run()
     check_for_updates()
     config = ui.get_embed_configuration()
+    start(config)
 
-    # suppose we have 2 gpus
-    if config.distr_mode == DistrMode.DDP:
-        world_size = torch.cuda.device_count()
-        run_distr(config, world_size)
-    else:
-        run(None, config, None)
 
 
 if __name__ == "__main__":

--- a/tomotwin/embed_main.py
+++ b/tomotwin/embed_main.py
@@ -609,7 +609,10 @@ def run_distr(config, world_size: int):
 
 
 def start(config):
-    # suppose we have 2 gpus
+    '''
+    Start the embedding procedure
+    '''
+
     if config.distr_mode == DistrMode.DDP:
         world_size = torch.cuda.device_count()
         run_distr(config, world_size)

--- a/tomotwin/locate_main.py
+++ b/tomotwin/locate_main.py
@@ -452,7 +452,9 @@ def run_non_maximum_suppression(class_frames: List[pd.DataFrame], boxsize: int, 
         )
     return class_frames
 
-def write_heatmaps(reference_names: List[str], out_path: str, heatmaps: List[np.array]) -> None:
+
+def write_heatmaps(reference_names: List[str], out_path: str, heatmaps: List[np.array], stride: int,
+                   tomo_input_shape: tuple) -> None:
     '''
     Write heatmaps to disk
     :param reference_names: Name of the references
@@ -461,6 +463,12 @@ def write_heatmaps(reference_names: List[str], out_path: str, heatmaps: List[np.
     :return: None
     '''
     assert len(reference_names) == len(heatmaps), "Unequal number of references and heatmaps"
+
+    def get_pad_tuble(total_pad):
+        if total_pad % 2 == 0:
+            return (total_pad // 2, total_pad // 2)
+        else:
+            return (total_pad // 2 + 1, total_pad // 2)
     for ref_i, ref_name in tqdm.tqdm(
             enumerate(reference_names), desc="Write heatmaps"
     ):
@@ -470,9 +478,17 @@ def write_heatmaps(reference_names: List[str], out_path: str, heatmaps: List[np.
             print("Write heatmap", os.path.join(out_path, ref_name + ".mrc"))
             vol = heatmaps[ref_i]
             vol = vol.astype(np.float32)
-            vol = zoom(vol, 2)
-            vol = np.pad(vol, ((18, 18), (18, 18), (18, 18)), "constant")
+            vol = zoom(vol, stride)
             vol = vol.swapaxes(0, 2)
+
+            get_pad_tuble(np.abs(tomo_input_shape[0] - vol.shape[0]))
+            vol = np.pad(
+                vol, (
+                    get_pad_tuble(np.abs(tomo_input_shape[0] - vol.shape[0])),
+                    get_pad_tuble(np.abs(tomo_input_shape[1] - vol.shape[1])),
+                    get_pad_tuble(np.abs(tomo_input_shape[2] - vol.shape[2]))),
+                "constant",
+                constant_values=np.min(vol))
             mrc.set_data(vol)
 
 
@@ -523,6 +539,7 @@ def run(conf: LocateConfiguration) -> None:
     del map_result
 
 
+
     class_vols = [t.attrs['heatmap'] for t in class_frames_and_vols if 'heatmap' in t.attrs]
     class_frames_and_vols = run_non_maximum_suppression(class_frames_and_vols, conf.boxsize, size_dict=size_dict)
 
@@ -538,7 +555,7 @@ def run(conf: LocateConfiguration) -> None:
 
     # Write picking headmaps
     if conf.write_heatmaps:
-        write_heatmaps(map_attrs["references"], out_path, class_vols)
+        write_heatmaps(map_attrs["references"], out_path, class_vols, stride, map_attrs["tomogram_input_shape"])
 
 def _main_():
     ui = LocateArgParseUI()

--- a/tomotwin/locate_main.py
+++ b/tomotwin/locate_main.py
@@ -470,7 +470,7 @@ def scale_and_pad_heatmap(vol: np.array, stride: int, tomo_input_shape: tuple) -
             get_pad_tuble(np.abs(tomo_input_shape[1] - vol.shape[1])),
             get_pad_tuble(np.abs(tomo_input_shape[2] - vol.shape[2]))),
         "constant",
-        constant_values=np.min(vol))
+        constant_values=np.min(vol) - 0.01 * np.abs(np.min(vol)))
     return vol
 
 

--- a/tomotwin/modules/tools/embedding_mask.py
+++ b/tomotwin/modules/tools/embedding_mask.py
@@ -509,7 +509,10 @@ class EmbeddingMaskTool(TomoTwinTool):
                     batch_size: int,
                     threshold: float,
                     dilation: float
-                    ):
+                    ) -> np.array:
+        '''
+        Calculates a mask based on median embedding
+        '''
         with tempfile.TemporaryDirectory() as tmp_pth:
             # Embed
             emb_out_pth = os.path.join(tmp_pth, "embed")
@@ -573,6 +576,9 @@ class EmbeddingMaskTool(TomoTwinTool):
             return bin_mask
 
     def intensity_mode(self, img: np.array) -> np.array:
+        '''
+        Calculates a mask based on intensity heuristics.
+        '''
         print("Background subtraction")
         filtered = ndimg.gaussian_filter(img, (10, 10, 10))
         background_removed = img - filtered

--- a/tomotwin/modules/tools/embedding_mask.py
+++ b/tomotwin/modules/tools/embedding_mask.py
@@ -505,7 +505,6 @@ class EmbeddingMaskTool(TomoTwinTool):
     def median_mode(self,
                     tomo_pth: str,
                     model_pth: str,
-                    output_path: str,
                     stride: int,
                     batch_size: int,
                     threshold: float,
@@ -599,7 +598,6 @@ class EmbeddingMaskTool(TomoTwinTool):
         if sys.argv[2] == "median":
             mask = self.median_mode(tomo_pth=args.input,
                                     model_pth=args.modelpth,
-                                    output_path=args.output,
                                     stride=args.stride,
                                     dilation=args.dilation,
                                     threshold=args.threshold,

--- a/tomotwin/modules/tools/embedding_mask.py
+++ b/tomotwin/modules/tools/embedding_mask.py
@@ -377,11 +377,11 @@ Exhibit B - "Incompatible With Secondary Licenses" Notice
 
 import argparse
 import os
+import sys
 import tempfile
 from argparse import ArgumentParser
 from glob import glob
 from types import SimpleNamespace
-from typing import Callable
 
 import mrcfile
 import numpy as np
@@ -571,15 +571,6 @@ class EmbeddingMaskTool(TomoTwinTool):
             bin_mask = np.zeros_like(mask, dtype=np.float32)
             bin_mask[mask] = 1
 
-            # Save to disk
-            os.makedirs(output_path, exist_ok=True)
-            mask_pth = os.path.join(output_path, "mask.mrc")
-            with mrcfile.new(
-                    mask_pth, overwrite=True
-            ) as mrc:
-                mrc.set_data(bin_mask)
-
-            print(f"Mask saved to {mask_pth}")
             return bin_mask
 
     def intensity_mode(self, img: np.array) -> np.array:
@@ -598,15 +589,6 @@ class EmbeddingMaskTool(TomoTwinTool):
         mask = min_img < t
         return mask
 
-    def create_embedding_mask(self, img: np.array, mask_calc: Callable[[np.array], np.array]) -> np.array:
-        """
-        Calculating the mask
-        """
-        mask = mask_calc(img)
-        print(f"Masked out: {100 - np.sum(mask) * 100 / np.prod(mask.shape):.2f}%")
-
-        return mask
-
     def run(self, args):
         """
         Runs the tools
@@ -614,8 +596,6 @@ class EmbeddingMaskTool(TomoTwinTool):
 
 
         print("Calculate mask")
-        import sys
-        print(sys.argv[2])
         if sys.argv[2] == "median":
             mask = self.median_mode(tomo_pth=args.input,
                                     model_pth=args.modelpth,


### PR DESCRIPTION
This PR refactors and adds a new function to the `tomotwin_tools.py embedding_mask` tool.

The old mask generation procedure can be called via `tomotwin_tools.py embedding_mask intensity -h`.

The new mask generation procedure can be called via  `tomotwin_tools.py embedding_mask median -h`.

The new procedure works as follows:

1. Coarse embedding of the tomogram with a stride of 5
2. Estimate median embedding
3. Calculate similarity heatmap for the median embedding
4. Create a mask by using pixels with a low similarity to the median embedding