### PR TITLE
Add manual recalculate umap workflow

### DIFF
--- a/docs/strategies/strategy_02.rst
+++ b/docs/strategies/strategy_02.rst
@@ -51,6 +51,6 @@ To calculate the mask, all you need is your tomogram and the latest TomoTwin mod
 
  .. prompt:: bash $
 
-    CUDA_VISIBLE_DEVICES=0,1 tomotwin_embed.py tomogram -v tomo/tomo.mrc -m tomotwin_latest.pth --mask mask/tomo_mask.mrc
+    CUDA_VISIBLE_DEVICES=0,1 tomotwin_embed.py tomogram -v tomo/tomo.mrc -m tomotwin_latest.pth --mask mask/tomo_mask.mrc -o out/embed/tomo/ -s 2
 
 Once the embeddings are computed, you can simply continue with either the reference or clustering workflow.

--- a/docs/strategies/strategy_04.rst
+++ b/docs/strategies/strategy_04.rst
@@ -1,0 +1,37 @@
+Strategy 3: Manually refining UMAPs from selected embeddings (Napari GPU workaround)
+========================================================
+
+When to use it
+--------------
+
+Use this strategy as a workaround to refine UMAP embeddings if you don't use Napari on a machine with GPUs.
+
+What it does
+------------
+
+This strategy allows you to manually recalculate UMAP embeddings that you can then reload in the Napari GUI.
+
+How to use it
+-------------
+
+1. Run the clustering workflow
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This strategy works with the clustering workflow. Therefore run the clustering workflow including cluster selection in Napari, save the clusters that you would like to recalculate.
+
+2. Recalculate the UMAP from the embeddings from each cluster of interest.
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Now we manually recalculate the UMAP for each cluster we would like to refine. For example if you labeled your cluster cool_protein:
+
+ .. prompt:: bash $
+
+    tomotwin_tools.py umap -i out/clustering/embeddings_cool_protein.temb -o out/clustering/refined/
+
+
+3. Visualize the refined UMAP in Napari
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Now you can load the refined UMAP in napari-boxmanager and look for subclusters that pick your protein of interest better
+
+

--- a/docs/strategies/strategy_04.rst
+++ b/docs/strategies/strategy_04.rst
@@ -1,4 +1,4 @@
-Strategy 3: Manually refining UMAPs from selected embeddings (Napari GPU workaround)
+Strategy 4: Manually refining UMAPs from selected embeddings (Napari GPU workaround)
 ========================================================
 
 When to use it

--- a/docs/strategies/strategy_overview.rst
+++ b/docs/strategies/strategy_overview.rst
@@ -10,3 +10,6 @@ Strategies
 
 .. _strategy-03:
 .. include:: strategy_03.rst
+
+.. _strategy-04:
+.. include:: strategy_04.rst


### PR DESCRIPTION
Added strategy 4 which details how users can manually refine UMAPs if their setup with napari-boxmanager cannot make use of GPUs. 