### PR TITLE
Add `mode` attribute to dataset metadata in `embed_main.py`

### DIFF
--- a/tests/test_embed_main.py
+++ b/tests/test_embed_main.py
@@ -203,7 +203,7 @@ class TestsEmbedMain(unittest.TestCase):
                 model_path=None,
                 volumes_path="my/fake/volume.mrc",
                 output_path=tmpdirname,
-                mode=None,
+                mode=EmbedMode.TOMO,
                 batchsize=3,
                 stride=1,
                 zrange=None,

--- a/tomotwin/embed_main.py
+++ b/tomotwin/embed_main.py
@@ -179,6 +179,7 @@ def embed_tomogram(
     df.attrs["tomogram_input_shape"] = tomo.shape
     df.attrs["tomotwin_config"] = embedor.tomotwin_config
     df.attrs["padding"] = conf.padding
+    df.attrs["mode"] = conf.mode.name
     if conf.zrange:
         df.attrs["zrange"] = conf.zrange
 


### PR DESCRIPTION
We need that metadata because we need to take it into account in napari.